### PR TITLE
Cache fonts and timestamped resources

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/_astro/*:
+  Cache-Control: public, max-age=3600000, immutable


### PR DESCRIPTION
I see a lot of font jitter when I load our blog, and it is because the `_astro` directory, which is all immutable stuff, is instead getting revalidated every time.