### PR TITLE
Add date and author in listing

### DIFF
--- a/src/components/AuthorImage.astro
+++ b/src/components/AuthorImage.astro
@@ -5,10 +5,18 @@ import max from "../content/authors/max.jpg";
 import tom from "../content/authors/tom.jpg";
 import steve from "../content/authors/steve.jpg";
 import jp from "../content/authors/jp.jpg";
+const authors = {
+    "Tom MacWright": tom,
+    "André Terron": andre,
+    "Steve Krouse": steve,
+    "Max McDonnell": max,
+    "JP Posma": jp,
+} as const;
 interface Props {
-	author: string;
+	author: keyof authors;
 }
 const { author } = Astro.props;
+const src = authors[author];
 ---
 <style>
 .avatar {
@@ -26,11 +34,5 @@ const { author } = Astro.props;
     class="avatar"
     alt={author}
     title={author}
-    src={{
-        "Tom MacWright": tom,
-        "André Terron": andre,
-        "Steve Krouse": steve,
-        "Max McDonnell": max,
-        "JP Posma": jp,
-    }[author]}
+    src={src}
 />

--- a/src/components/AuthorImage.astro
+++ b/src/components/AuthorImage.astro
@@ -11,9 +11,13 @@ const authors = {
     "Steve Krouse": steve,
     "Max McDonnell": max,
     "JP Posma": jp,
-} as const;
+};
 interface Props {
-	author: keyof authors;
+	author: "Tom MacWright" |
+    "André Terron" |
+    "Steve Krouse" |
+    "Max McDonnell" |
+    "JP Posma"
 }
 const { author } = Astro.props;
 const src = authors[author];

--- a/src/components/AuthorImage.astro
+++ b/src/components/AuthorImage.astro
@@ -1,0 +1,36 @@
+---
+import { Image } from "astro:assets";
+import andre from "../content/authors/andre.jpg";
+import max from "../content/authors/max.jpg";
+import tom from "../content/authors/tom.jpg";
+import steve from "../content/authors/steve.jpg";
+import jp from "../content/authors/jp.jpg";
+interface Props {
+	author: string;
+}
+const { author } = Astro.props;
+---
+<style>
+.avatar {
+    border-radius: 4px;
+    vertical-align: middle;
+    margin-right: 2px;
+    margin-top: -3px;
+}
+</style>
+
+<Image
+    densities={[1, 2, 3]}
+    width="20"
+    height="20"
+    class="avatar"
+    alt={author}
+    title={author}
+    src={{
+        "Tom MacWright": tom,
+        "André Terron": andre,
+        "Steve Krouse": steve,
+        "Max McDonnell": max,
+        "JP Posma": jp,
+    }[author]}
+/>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,12 +6,8 @@ import EditLink from "../components/EditLink.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import FormattedDate from "../components/FormattedDate.astro";
+import AuthorImage from "../components/AuthorImage.astro";
 import MermaidChart from "../components/MermaidChart.astro";
-import andre from "../content/authors/andre.jpg";
-import max from "../content/authors/max.jpg";
-import tom from "../content/authors/tom.jpg";
-import steve from "../content/authors/steve.jpg";
-import jp from "../content/authors/jp.jpg";
 
 type Props = CollectionEntry<"blog">["data"] & { id: string };
 
@@ -103,12 +99,6 @@ const { id, title, image, description, author, pubDate, updatedDate, heroImage }
                     font-size: 30px;
                 }
             }
-            .avatar {
-                border-radius: 4px;
-                vertical-align: middle;
-                margin-right: 2px;
-                margin-top: -3px;
-            }
         </style>
     </head>
 
@@ -134,20 +124,7 @@ const { id, title, image, description, author, pubDate, updatedDate, heroImage }
                         <div class="title">
                             <h1 itemprop="name">{title}</h1>
                             <div class="date">
-                                <Image
-                                    densities={[1, 2, 3]}
-                                    width="20"
-                                    height="20"
-                                    class="avatar"
-                                    alt={author}
-                                    src={{
-                                        "Tom MacWright": tom,
-                                        "André Terron": andre,
-                                        "Steve Krouse": steve,
-                                        "Max McDonnell": max,
-                                        "JP Posma": jp,
-                                    }[author]}
-                                />
+                              <AuthorImage author={author} />
                                 <span itemprop="author">{author}</span>
                                 on
                                 <FormattedDate date={pubDate} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../components/FormattedDate.astro';
+import AuthorImage from "../components/AuthorImage.astro";
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => {
@@ -102,9 +103,10 @@ const posts = (await getCollection('blog')).sort(
               posts.map((post) => (
                 <li>
                   <a href={`/blog/${post.slug}/`}>
-                      <h4 class="title">{post.data.title}</h4>
+                    <h4 class="title">{post.data.title}</h4>
+                    <AuthorImage author={post.data.author} />
+                    <FormattedDate date={post.data.pubDate} />
                     <p class="description">{post.data.description}</p>
-                    
                   </a>
                 </li>
               ))


### PR DESCRIPTION
- Fixes #133 

Adds dates and authors to the listing on the homepage:

![CleanShot 2024-09-09 at 12 18 57@2x](https://github.com/user-attachments/assets/96fc50b6-11a8-4fac-bfc7-7a811e49514c)
