### PR TITLE
fix: update fal blog post val url

### DIFF
--- a/src/content/blog/fal.mdx
+++ b/src/content/blog/fal.mdx
@@ -57,7 +57,7 @@ The quickest way to get started is to fork one of these starter apps:
   </div>
 
   <div align="center">
-    <a href="https://www.val.town/v/drochetti/faltown">
+    <a href="https://www.val.town/v/fal/faltown">
       <Image src=  {Faltown} alt="Simplified Midjourney, with type-safe API client, blob storage" class="border" />
       <figcaption>
       "Faltown" – variants, API client, blob storage


### PR DESCRIPTION
The previous URL was not pointing to the official fal account.